### PR TITLE
docs(readme): replace lazy.nvim FAQ with recipes reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,9 @@ luarocks install nonicons.nvim
 
 ## FAQ
 
-**How do I install with lazy.nvim?**
+**How do I integrate with plugin \<X\>?**
 
-```lua
-{
-  'barrettruth/nonicons.nvim',
-  dependencies = { 'nvim-tree/nvim-web-devicons' },
-}
-```
+See `:help nonicons-recipes`.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 ## Features
 
-- Replaces [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons) glyphs with nonicons font icons
+- Replaces [nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons)
+  glyphs with nonicons font icons
 - Any plugin using nvim-web-devicons works automatically
 
 ## Requirements

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771177547,
+        "narHash": "sha256-trTtk3WTOHz7hSw89xIIvahkgoFJYQ0G43IlqprFoMA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ac055f38c798b0d87695240c7b761b82fc7e5bc2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}


### PR DESCRIPTION
Problem: the FAQ inlined a lazy.nvim snippet that duplicates vimdoc content and doesn't cover other plugin integrations.

Solution: replace with a generic "How do I integrate with plugin <X>?" entry pointing to :help nonicons-recipes. Also track flake.lock.