### PR TITLE
feat: add public file-icon API

### DIFF
--- a/doc/nonicons.nvim.txt
+++ b/doc/nonicons.nvim.txt
@@ -56,6 +56,33 @@ API                                                            *nonicons-api*
     Returns: ~
         `string?`  The single-character nonicons glyph
 
+                                                       *nonicons.get_icon()*
+`require('nonicons').get_icon(name, ext)`
+    Returns the nonicons character for a file, resolved by filename and/or
+    extension. Returns `nil` if no match is found (caller decides fallback).
+
+    Resolution order: exact extension → exact filename → extracted extension.
+
+    Parameters: ~
+        {name}  `string?`  Filename (e.g. `'init.lua'`, `'Makefile'`)
+        {ext}   `string?`  File extension (e.g. `'lua'`, `'py'`)
+
+    Returns: ~
+        `string?`  The single-character nonicons glyph
+
+                                              *nonicons.get_icon_by_filetype()*
+`require('nonicons').get_icon_by_filetype(ft)`
+    Returns the nonicons character for a vim filetype. Returns `nil` if no
+    match is found.
+
+    Resolution order: direct mapping key → extension table → filetype table.
+
+    Parameters: ~
+        {ft}  `string`  Vim filetype (e.g. `'python'`, `'typescriptreact'`)
+
+    Returns: ~
+        `string?`  The single-character nonicons glyph
+
                                                         *nonicons.mapping*
 `require('nonicons').mapping`
     The raw `table<string, integer>` mapping icon names to Unicode codepoints.
@@ -128,8 +155,9 @@ mason.nvim ~
 
 oil.nvim ~
 
-    No configuration needed. oil.nvim reads the devicons extension/filename
-    tables directly, which nonicons.nvim mutates on load.
+    No configuration needed. oil.nvim detects nonicons.nvim and uses it as a
+    direct icon provider. If devicons is also loaded, the devicons override
+    still applies to other plugins.
 
 fzf-lua ~
 >lua

--- a/lua/nonicons/init.lua
+++ b/lua/nonicons/init.lua
@@ -40,4 +40,18 @@ function M.apply()
   end
 end
 
+function M.get_icon(name, ext)
+  local key = require('nonicons.resolve').resolve_name(name, ext)
+  if key then
+    return M.get(key)
+  end
+end
+
+function M.get_icon_by_filetype(ft)
+  local key = require('nonicons.resolve').resolve_filetype(ft)
+  if key then
+    return M.get(key)
+  end
+end
+
 return M

--- a/lua/nonicons/override.lua
+++ b/lua/nonicons/override.lua
@@ -1,4 +1,5 @@
 local mapping = require('nonicons.mapping')
+local resolve_mod = require('nonicons.resolve')
 
 local function char(name)
   local code = mapping[name]
@@ -9,440 +10,10 @@ end
 
 local fallback_icon
 
-local ext_map = {
-  lua = 'lua',
-  luac = 'lua',
-  luau = 'lua',
-
-  js = 'javascript',
-  cjs = 'javascript',
-  mjs = 'javascript',
-  jsx = 'react',
-  tsx = 'react',
-
-  ts = 'typescript',
-  cts = 'typescript',
-  mts = 'typescript',
-  ['d.ts'] = 'typescript',
-
-  py = 'python',
-  pyc = 'python',
-  pyd = 'python',
-  pyi = 'python',
-  pyo = 'python',
-  pyw = 'python',
-  pyx = 'python',
-
-  rb = 'ruby',
-  rake = 'ruby',
-  gemspec = 'ruby',
-
-  rs = 'rust',
-  rlib = 'rust',
-
-  go = 'go',
-
-  c = 'c',
-  h = 'c',
-
-  cpp = 'c-plusplus',
-  cc = 'c-plusplus',
-  cxx = 'c-plusplus',
-  ['c++'] = 'c-plusplus',
-  cp = 'c-plusplus',
-  cppm = 'c-plusplus',
-  cxxm = 'c-plusplus',
-  mpp = 'c-plusplus',
-  hh = 'c-plusplus',
-  hpp = 'c-plusplus',
-  hxx = 'c-plusplus',
-  ixx = 'c-plusplus',
-  mm = 'c-plusplus',
-
-  cs = 'c-sharp',
-  cshtml = 'c-sharp',
-  csproj = 'c-sharp',
-
-  java = 'java',
-  jar = 'java',
-
-  kt = 'kotlin',
-  kts = 'kotlin',
-
-  swift = 'swift',
-
-  dart = 'dart',
-
-  elm = 'elm',
-
-  ex = 'elixir',
-  exs = 'elixir',
-  eex = 'elixir',
-  heex = 'elixir',
-  leex = 'elixir',
-
-  vue = 'vue',
-
-  svelte = 'svelte',
-
-  html = 'html',
-  htm = 'html',
-
-  css = 'css',
-  scss = 'css',
-  sass = 'css',
-  less = 'css',
-  styl = 'css',
-
-  json = 'json',
-  json5 = 'json',
-  jsonc = 'json',
-  cson = 'json',
-
-  yaml = 'yaml',
-  yml = 'yaml',
-
-  toml = 'toml',
-
-  md = 'markdown',
-  markdown = 'markdown',
-  mdx = 'markdown',
-
-  php = 'php',
-  ['blade.php'] = 'php',
-
-  pl = 'perl',
-  pm = 'perl',
-
-  r = 'r',
-  R = 'r',
-  rmd = 'r',
-
-  scala = 'scala',
-  sc = 'scala',
-  sbt = 'scala',
-
-  vim = 'vim',
-
-  graphql = 'graphql',
-  gql = 'graphql',
-
-  tf = 'terraform',
-  tfvars = 'terraform',
-
-  Dockerfile = 'docker',
-  dockerignore = 'docker',
-
-  angular = 'angular',
-
-  sh = 'terminal',
-  bash = 'terminal',
-  zsh = 'terminal',
-  fish = 'terminal',
-  ksh = 'terminal',
-  csh = 'terminal',
-  terminal = 'terminal',
-  ps1 = 'terminal',
-
-  nix = 'code',
-
-  sql = 'database',
-  sqlite = 'database',
-  sqlite3 = 'database',
-  db = 'database',
-  dump = 'database',
-
-  rss = 'rss',
-  tmux = 'tmux',
-  nginx = 'nginx',
-
-  diff = 'diff',
-  patch = 'diff',
-
-  lock = 'lock',
-  lck = 'lock',
-
-  conf = 'gear',
-  cfg = 'gear',
-  ini = 'gear',
-  env = 'key',
-
-  git = 'git-branch',
-
-  license = 'law',
-
-  log = 'log',
-
-  xml = 'code',
-  xslt = 'code',
-
-  tex = 'book',
-  bib = 'book',
-
-  png = 'image',
-  jpg = 'image',
-  jpeg = 'image',
-  gif = 'image',
-  bmp = 'image',
-  ico = 'image',
-  webp = 'image',
-  avif = 'image',
-  svg = 'image',
-  tiff = 'image',
-  jxl = 'image',
-
-  zip = 'file-zip',
-  gz = 'file-zip',
-  tgz = 'file-zip',
-  ['7z'] = 'file-zip',
-  rar = 'file-zip',
-  bz = 'file-zip',
-  bz2 = 'file-zip',
-  bz3 = 'file-zip',
-  xz = 'file-zip',
-  zst = 'file-zip',
-  txz = 'file-zip',
-  tar = 'file-zip',
-
-  bin = 'file-binary',
-  exe = 'file-binary',
-  dll = 'file-binary',
-  so = 'file-binary',
-  o = 'file-binary',
-  a = 'file-binary',
-  elf = 'file-binary',
-  ko = 'file-binary',
-  lib = 'file-binary',
-  out = 'file-binary',
-
-  mp3 = 'play',
-  mp4 = 'play',
-  mkv = 'play',
-  mov = 'play',
-  avi = 'play',
-  flac = 'play',
-  ogg = 'play',
-  wav = 'play',
-  webm = 'play',
-  aac = 'play',
-  m4a = 'play',
-  m4v = 'play',
-  ogv = 'play',
-  wma = 'play',
-  wmv = 'play',
-
-  ttf = 'typography',
-  otf = 'typography',
-  woff = 'typography',
-  woff2 = 'typography',
-  eot = 'typography',
-
-  pdf = 'file',
-  doc = 'file',
-  docx = 'file',
-  ppt = 'file',
-  pptx = 'file',
-  xls = 'file',
-  xlsx = 'file',
-  csv = 'file',
-  txt = 'file',
-
-  erl = 'code',
-  hrl = 'code',
-  hs = 'code',
-  lhs = 'code',
-  ml = 'code',
-  mli = 'code',
-  clj = 'code',
-  cljs = 'code',
-  cljc = 'code',
-  edn = 'code',
-  fnl = 'code',
-  el = 'code',
-  elc = 'code',
-  eln = 'code',
-  nim = 'code',
-  zig = 'code',
-  odin = 'code',
-  gleam = 'code',
-  cr = 'code',
-  jl = 'code',
-  nu = 'code',
-  pro = 'code',
-  scm = 'code',
-  rkt = 'code',
-  sol = 'code',
-  wasm = 'code',
-  ipynb = 'code',
-  gradle = 'code',
-  groovy = 'code',
-  ino = 'code',
-  prisma = 'code',
-  astro = 'code',
-  hx = 'code',
-  d = 'code',
-  ada = 'code',
-  adb = 'code',
-  ads = 'code',
-  f90 = 'code',
-  vala = 'code',
-  v = 'code',
-  vh = 'code',
-  vhd = 'code',
-  vhdl = 'code',
-  sv = 'code',
-  svh = 'code',
-  mo = 'code',
-  mojo = 'code',
-}
-
-local filename_map = {
-  ['dockerfile'] = 'docker',
-  ['containerfile'] = 'docker',
-  ['docker-compose.yml'] = 'docker',
-  ['docker-compose.yaml'] = 'docker',
-  ['compose.yml'] = 'docker',
-  ['compose.yaml'] = 'docker',
-  ['.dockerignore'] = 'docker',
-
-  ['.gitignore'] = 'git-branch',
-  ['.gitconfig'] = 'git-branch',
-  ['.gitattributes'] = 'git-branch',
-  ['.gitmodules'] = 'git-branch',
-  ['.git-blame-ignore-revs'] = 'git-branch',
-  ['.mailmap'] = 'git-branch',
-  ['commit_editmsg'] = 'git-commit',
-
-  ['.bashrc'] = 'terminal',
-  ['.bash_profile'] = 'terminal',
-  ['.zshrc'] = 'terminal',
-  ['.zshenv'] = 'terminal',
-  ['.zprofile'] = 'terminal',
-  ['makefile'] = 'terminal',
-  ['gnumakefile'] = 'terminal',
-  ['.justfile'] = 'terminal',
-  ['justfile'] = 'terminal',
-
-  ['.eslintrc'] = 'eslint',
-  ['.eslintignore'] = 'eslint',
-  ['eslint.config.js'] = 'eslint',
-  ['eslint.config.cjs'] = 'eslint',
-  ['eslint.config.mjs'] = 'eslint',
-  ['eslint.config.ts'] = 'eslint',
-
-  ['.prettierrc'] = 'prettier',
-  ['.prettierignore'] = 'prettier',
-  ['.prettierrc.js'] = 'prettier',
-  ['.prettierrc.cjs'] = 'prettier',
-  ['.prettierrc.mjs'] = 'prettier',
-  ['.prettierrc.json'] = 'prettier',
-  ['.prettierrc.json5'] = 'prettier',
-  ['.prettierrc.toml'] = 'prettier',
-  ['.prettierrc.yaml'] = 'prettier',
-  ['.prettierrc.yml'] = 'prettier',
-  ['prettier.config.js'] = 'prettier',
-  ['prettier.config.cjs'] = 'prettier',
-  ['prettier.config.mjs'] = 'prettier',
-  ['prettier.config.ts'] = 'prettier',
-
-  ['.babelrc'] = 'babel',
-
-  ['package.json'] = 'npm',
-  ['package-lock.json'] = 'npm',
-  ['.npmrc'] = 'npm',
-  ['.npmignore'] = 'npm',
-
-  ['pnpm-lock.yaml'] = 'yarn',
-  ['pnpm-workspace.yaml'] = 'package',
-  ['.pnpmfile.cjs'] = 'npm',
-  ['bun.lock'] = 'package',
-  ['bun.lockb'] = 'package',
-
-  ['tsconfig.json'] = 'typescript',
-
-  ['license'] = 'law',
-  ['license.md'] = 'law',
-  ['copying'] = 'law',
-  ['copying.lesser'] = 'law',
-  ['unlicense'] = 'law',
-
-  ['tmux.conf'] = 'tmux',
-  ['tmux.conf.local'] = 'tmux',
-
-  ['readme'] = 'book',
-  ['readme.md'] = 'book',
-
-  ['go.mod'] = 'go',
-  ['go.sum'] = 'go',
-  ['go.work'] = 'go',
-
-  ['.vimrc'] = 'vim',
-  ['.gvimrc'] = 'vim',
-  ['_vimrc'] = 'vim',
-  ['_gvimrc'] = 'vim',
-
-  ['next.config.js'] = 'next',
-  ['next.config.cjs'] = 'next',
-  ['next.config.ts'] = 'next',
-
-  ['svelte.config.js'] = 'svelte',
-
-  ['mix.lock'] = 'elixir',
-
-  ['.env'] = 'key',
-
-  ['config'] = 'gear',
-  ['.editorconfig'] = 'gear',
-
-  ['procfile'] = 'server',
-
-  ['Gemfile'] = 'ruby',
-  ['rakefile'] = 'ruby',
-
-  ['Jenkinsfile'] = 'gear',
-
-  ['.gitlab-ci.yml'] = 'logo-github',
-
-  ['security'] = 'shield',
-  ['security.md'] = 'shield',
-
-  ['robots.txt'] = 'globe',
-
-  ['vite.config.js'] = 'code',
-  ['vite.config.ts'] = 'code',
-  ['vite.config.cjs'] = 'code',
-  ['vite.config.cts'] = 'code',
-  ['vite.config.mjs'] = 'code',
-  ['vite.config.mts'] = 'code',
-
-  ['build.gradle'] = 'code',
-  ['settings.gradle'] = 'code',
-
-  ['pom.xml'] = 'code',
-
-  ['hyprland.conf'] = 'gear',
-  ['hyprlock.conf'] = 'gear',
-  ['hypridle.conf'] = 'gear',
-  ['hyprpaper.conf'] = 'gear',
-
-  ['cmakelists.txt'] = 'code',
-  ['code_of_conduct'] = 'book',
-  ['code_of_conduct.md'] = 'book',
-}
-
 local function resolve(name, ext)
-  if ext and ext_map[ext] then
-    return char(ext_map[ext])
-  end
-  if name then
-    local lower = name:lower()
-    if filename_map[lower] then
-      return char(filename_map[lower])
-    end
-    local dot_ext = lower:match('%.(.+)$')
-    if dot_ext and ext_map[dot_ext] then
-      return char(ext_map[dot_ext])
-    end
+  local key = resolve_mod.resolve_name(name, ext)
+  if key then
+    return char(key)
   end
   return fallback_icon
 end
@@ -470,8 +41,8 @@ function M.apply()
   devicons.get_icon_by_filetype = function(ft, opts)
     local icon, hl = orig_get_icon_by_filetype(ft, opts)
     if icon then
-      local nonicons_name = ext_map[ft]
-      icon = nonicons_name and char(nonicons_name) or fallback_icon
+      local key = resolve_mod.resolve_filetype(ft)
+      icon = key and char(key) or fallback_icon
     end
     return icon, hl
   end
@@ -507,8 +78,8 @@ function M.apply()
   devicons.get_icon_colors_by_filetype = function(ft, opts)
     local icon, color, cterm_color = orig_get_icon_colors_by_filetype(ft, opts)
     if icon then
-      local nonicons_name = ext_map[ft]
-      icon = nonicons_name and char(nonicons_name) or fallback_icon
+      local key = resolve_mod.resolve_filetype(ft)
+      icon = key and char(key) or fallback_icon
     end
     return icon, color, cterm_color
   end
@@ -517,8 +88,8 @@ function M.apply()
   devicons.get_icon_color_by_filetype = function(ft, opts)
     local icon, color = orig_get_icon_color_by_filetype(ft, opts)
     if icon then
-      local nonicons_name = ext_map[ft]
-      icon = nonicons_name and char(nonicons_name) or fallback_icon
+      local key = resolve_mod.resolve_filetype(ft)
+      icon = key and char(key) or fallback_icon
     end
     return icon, color
   end
@@ -527,8 +98,8 @@ function M.apply()
   devicons.get_icon_cterm_color_by_filetype = function(ft, opts)
     local icon, cterm_color = orig_get_icon_cterm_color_by_filetype(ft, opts)
     if icon then
-      local nonicons_name = ext_map[ft]
-      icon = nonicons_name and char(nonicons_name) or fallback_icon
+      local key = resolve_mod.resolve_filetype(ft)
+      icon = key and char(key) or fallback_icon
     end
     return icon, cterm_color
   end
@@ -536,7 +107,7 @@ function M.apply()
   local function override_tables()
     local by_ext = devicons.get_icons_by_extension()
     for ext, data in pairs(by_ext) do
-      local name = ext_map[ext]
+      local name = resolve_mod.ext_map[ext]
       if name then
         data.icon = char(name) or fallback_icon
       else
@@ -546,7 +117,7 @@ function M.apply()
 
     local by_filename = devicons.get_icons_by_filename()
     for fname, data in pairs(by_filename) do
-      local name = filename_map[fname]
+      local name = resolve_mod.filename_map[fname]
       if name then
         data.icon = char(name) or fallback_icon
       else

--- a/lua/nonicons/resolve.lua
+++ b/lua/nonicons/resolve.lua
@@ -1,0 +1,469 @@
+local M = {}
+
+M.ext_map = {
+  lua = 'lua',
+  luac = 'lua',
+  luau = 'lua',
+
+  js = 'javascript',
+  cjs = 'javascript',
+  mjs = 'javascript',
+  jsx = 'react',
+  tsx = 'react',
+
+  ts = 'typescript',
+  cts = 'typescript',
+  mts = 'typescript',
+  ['d.ts'] = 'typescript',
+
+  py = 'python',
+  pyc = 'python',
+  pyd = 'python',
+  pyi = 'python',
+  pyo = 'python',
+  pyw = 'python',
+  pyx = 'python',
+
+  rb = 'ruby',
+  rake = 'ruby',
+  gemspec = 'ruby',
+
+  rs = 'rust',
+  rlib = 'rust',
+
+  go = 'go',
+
+  c = 'c',
+  h = 'c',
+
+  cpp = 'c-plusplus',
+  cc = 'c-plusplus',
+  cxx = 'c-plusplus',
+  ['c++'] = 'c-plusplus',
+  cp = 'c-plusplus',
+  cppm = 'c-plusplus',
+  cxxm = 'c-plusplus',
+  mpp = 'c-plusplus',
+  hh = 'c-plusplus',
+  hpp = 'c-plusplus',
+  hxx = 'c-plusplus',
+  ixx = 'c-plusplus',
+  mm = 'c-plusplus',
+
+  cs = 'c-sharp',
+  cshtml = 'c-sharp',
+  csproj = 'c-sharp',
+
+  java = 'java',
+  jar = 'java',
+
+  kt = 'kotlin',
+  kts = 'kotlin',
+
+  swift = 'swift',
+
+  dart = 'dart',
+
+  elm = 'elm',
+
+  ex = 'elixir',
+  exs = 'elixir',
+  eex = 'elixir',
+  heex = 'elixir',
+  leex = 'elixir',
+
+  vue = 'vue',
+
+  svelte = 'svelte',
+
+  html = 'html',
+  htm = 'html',
+
+  css = 'css',
+  scss = 'css',
+  sass = 'css',
+  less = 'css',
+  styl = 'css',
+
+  json = 'json',
+  json5 = 'json',
+  jsonc = 'json',
+  cson = 'json',
+
+  yaml = 'yaml',
+  yml = 'yaml',
+
+  toml = 'toml',
+
+  md = 'markdown',
+  markdown = 'markdown',
+  mdx = 'markdown',
+
+  php = 'php',
+  ['blade.php'] = 'php',
+
+  pl = 'perl',
+  pm = 'perl',
+
+  r = 'r',
+  R = 'r',
+  rmd = 'r',
+
+  scala = 'scala',
+  sc = 'scala',
+  sbt = 'scala',
+
+  vim = 'vim',
+
+  graphql = 'graphql',
+  gql = 'graphql',
+
+  tf = 'terraform',
+  tfvars = 'terraform',
+
+  Dockerfile = 'docker',
+  dockerignore = 'docker',
+
+  angular = 'angular',
+
+  sh = 'terminal',
+  bash = 'terminal',
+  zsh = 'terminal',
+  fish = 'terminal',
+  ksh = 'terminal',
+  csh = 'terminal',
+  terminal = 'terminal',
+  ps1 = 'terminal',
+
+  nix = 'code',
+
+  sql = 'database',
+  sqlite = 'database',
+  sqlite3 = 'database',
+  db = 'database',
+  dump = 'database',
+
+  rss = 'rss',
+  tmux = 'tmux',
+  nginx = 'nginx',
+
+  diff = 'diff',
+  patch = 'diff',
+
+  lock = 'lock',
+  lck = 'lock',
+
+  conf = 'gear',
+  cfg = 'gear',
+  ini = 'gear',
+  env = 'key',
+
+  git = 'git-branch',
+
+  license = 'law',
+
+  log = 'log',
+
+  xml = 'code',
+  xslt = 'code',
+
+  tex = 'book',
+  bib = 'book',
+
+  png = 'image',
+  jpg = 'image',
+  jpeg = 'image',
+  gif = 'image',
+  bmp = 'image',
+  ico = 'image',
+  webp = 'image',
+  avif = 'image',
+  svg = 'image',
+  tiff = 'image',
+  jxl = 'image',
+
+  zip = 'file-zip',
+  gz = 'file-zip',
+  tgz = 'file-zip',
+  ['7z'] = 'file-zip',
+  rar = 'file-zip',
+  bz = 'file-zip',
+  bz2 = 'file-zip',
+  bz3 = 'file-zip',
+  xz = 'file-zip',
+  zst = 'file-zip',
+  txz = 'file-zip',
+  tar = 'file-zip',
+
+  bin = 'file-binary',
+  exe = 'file-binary',
+  dll = 'file-binary',
+  so = 'file-binary',
+  o = 'file-binary',
+  a = 'file-binary',
+  elf = 'file-binary',
+  ko = 'file-binary',
+  lib = 'file-binary',
+  out = 'file-binary',
+
+  mp3 = 'play',
+  mp4 = 'play',
+  mkv = 'play',
+  mov = 'play',
+  avi = 'play',
+  flac = 'play',
+  ogg = 'play',
+  wav = 'play',
+  webm = 'play',
+  aac = 'play',
+  m4a = 'play',
+  m4v = 'play',
+  ogv = 'play',
+  wma = 'play',
+  wmv = 'play',
+
+  ttf = 'typography',
+  otf = 'typography',
+  woff = 'typography',
+  woff2 = 'typography',
+  eot = 'typography',
+
+  pdf = 'file',
+  doc = 'file',
+  docx = 'file',
+  ppt = 'file',
+  pptx = 'file',
+  xls = 'file',
+  xlsx = 'file',
+  csv = 'file',
+  txt = 'file',
+
+  erl = 'code',
+  hrl = 'code',
+  hs = 'code',
+  lhs = 'code',
+  ml = 'code',
+  mli = 'code',
+  clj = 'code',
+  cljs = 'code',
+  cljc = 'code',
+  edn = 'code',
+  fnl = 'code',
+  el = 'code',
+  elc = 'code',
+  eln = 'code',
+  nim = 'code',
+  zig = 'code',
+  odin = 'code',
+  gleam = 'code',
+  cr = 'code',
+  jl = 'code',
+  nu = 'code',
+  pro = 'code',
+  scm = 'code',
+  rkt = 'code',
+  sol = 'code',
+  wasm = 'code',
+  ipynb = 'code',
+  gradle = 'code',
+  groovy = 'code',
+  ino = 'code',
+  prisma = 'code',
+  astro = 'code',
+  hx = 'code',
+  d = 'code',
+  ada = 'code',
+  adb = 'code',
+  ads = 'code',
+  f90 = 'code',
+  vala = 'code',
+  v = 'code',
+  vh = 'code',
+  vhd = 'code',
+  vhdl = 'code',
+  sv = 'code',
+  svh = 'code',
+  mo = 'code',
+  mojo = 'code',
+}
+
+M.filename_map = {
+  ['dockerfile'] = 'docker',
+  ['containerfile'] = 'docker',
+  ['docker-compose.yml'] = 'docker',
+  ['docker-compose.yaml'] = 'docker',
+  ['compose.yml'] = 'docker',
+  ['compose.yaml'] = 'docker',
+  ['.dockerignore'] = 'docker',
+
+  ['.gitignore'] = 'git-branch',
+  ['.gitconfig'] = 'git-branch',
+  ['.gitattributes'] = 'git-branch',
+  ['.gitmodules'] = 'git-branch',
+  ['.git-blame-ignore-revs'] = 'git-branch',
+  ['.mailmap'] = 'git-branch',
+  ['commit_editmsg'] = 'git-commit',
+
+  ['.bashrc'] = 'terminal',
+  ['.bash_profile'] = 'terminal',
+  ['.zshrc'] = 'terminal',
+  ['.zshenv'] = 'terminal',
+  ['.zprofile'] = 'terminal',
+  ['makefile'] = 'terminal',
+  ['gnumakefile'] = 'terminal',
+  ['.justfile'] = 'terminal',
+  ['justfile'] = 'terminal',
+
+  ['.eslintrc'] = 'eslint',
+  ['.eslintignore'] = 'eslint',
+  ['eslint.config.js'] = 'eslint',
+  ['eslint.config.cjs'] = 'eslint',
+  ['eslint.config.mjs'] = 'eslint',
+  ['eslint.config.ts'] = 'eslint',
+
+  ['.prettierrc'] = 'prettier',
+  ['.prettierignore'] = 'prettier',
+  ['.prettierrc.js'] = 'prettier',
+  ['.prettierrc.cjs'] = 'prettier',
+  ['.prettierrc.mjs'] = 'prettier',
+  ['.prettierrc.json'] = 'prettier',
+  ['.prettierrc.json5'] = 'prettier',
+  ['.prettierrc.toml'] = 'prettier',
+  ['.prettierrc.yaml'] = 'prettier',
+  ['.prettierrc.yml'] = 'prettier',
+  ['prettier.config.js'] = 'prettier',
+  ['prettier.config.cjs'] = 'prettier',
+  ['prettier.config.mjs'] = 'prettier',
+  ['prettier.config.ts'] = 'prettier',
+
+  ['.babelrc'] = 'babel',
+
+  ['package.json'] = 'npm',
+  ['package-lock.json'] = 'npm',
+  ['.npmrc'] = 'npm',
+  ['.npmignore'] = 'npm',
+
+  ['pnpm-lock.yaml'] = 'yarn',
+  ['pnpm-workspace.yaml'] = 'package',
+  ['.pnpmfile.cjs'] = 'npm',
+  ['bun.lock'] = 'package',
+  ['bun.lockb'] = 'package',
+
+  ['tsconfig.json'] = 'typescript',
+
+  ['license'] = 'law',
+  ['license.md'] = 'law',
+  ['copying'] = 'law',
+  ['copying.lesser'] = 'law',
+  ['unlicense'] = 'law',
+
+  ['tmux.conf'] = 'tmux',
+  ['tmux.conf.local'] = 'tmux',
+
+  ['readme'] = 'book',
+  ['readme.md'] = 'book',
+
+  ['go.mod'] = 'go',
+  ['go.sum'] = 'go',
+  ['go.work'] = 'go',
+
+  ['.vimrc'] = 'vim',
+  ['.gvimrc'] = 'vim',
+  ['_vimrc'] = 'vim',
+  ['_gvimrc'] = 'vim',
+
+  ['next.config.js'] = 'next',
+  ['next.config.cjs'] = 'next',
+  ['next.config.ts'] = 'next',
+
+  ['svelte.config.js'] = 'svelte',
+
+  ['mix.lock'] = 'elixir',
+
+  ['.env'] = 'key',
+
+  ['config'] = 'gear',
+  ['.editorconfig'] = 'gear',
+
+  ['procfile'] = 'server',
+
+  ['gemfile'] = 'ruby',
+  ['rakefile'] = 'ruby',
+
+  ['jenkinsfile'] = 'gear',
+
+  ['.gitlab-ci.yml'] = 'logo-github',
+
+  ['security'] = 'shield',
+  ['security.md'] = 'shield',
+
+  ['robots.txt'] = 'globe',
+
+  ['vite.config.js'] = 'code',
+  ['vite.config.ts'] = 'code',
+  ['vite.config.cjs'] = 'code',
+  ['vite.config.cts'] = 'code',
+  ['vite.config.mjs'] = 'code',
+  ['vite.config.mts'] = 'code',
+
+  ['build.gradle'] = 'code',
+  ['settings.gradle'] = 'code',
+
+  ['pom.xml'] = 'code',
+
+  ['hyprland.conf'] = 'gear',
+  ['hyprlock.conf'] = 'gear',
+  ['hypridle.conf'] = 'gear',
+  ['hyprpaper.conf'] = 'gear',
+
+  ['cmakelists.txt'] = 'code',
+  ['code_of_conduct'] = 'book',
+  ['code_of_conduct.md'] = 'book',
+}
+
+M.ft_map = {
+  typescriptreact = 'react',
+  javascriptreact = 'react',
+  make = 'terminal',
+  dockerfile = 'docker',
+  gitcommit = 'git-commit',
+  gitrebase = 'git-branch',
+  help = 'book',
+  text = 'file',
+  plaintex = 'book',
+  latex = 'book',
+}
+
+function M.resolve_name(name, ext)
+  if ext and M.ext_map[ext] then
+    return M.ext_map[ext]
+  end
+  if name then
+    local lower = name:lower()
+    if M.filename_map[lower] then
+      return M.filename_map[lower]
+    end
+    local dot_ext = lower:match('%.(.+)$')
+    if dot_ext and M.ext_map[dot_ext] then
+      return M.ext_map[dot_ext]
+    end
+  end
+end
+
+function M.resolve_filetype(ft)
+  if not ft then
+    return
+  end
+  local mapping = require('nonicons.mapping')
+  if mapping[ft] then
+    return ft
+  end
+  if M.ext_map[ft] then
+    return M.ext_map[ft]
+  end
+  if M.ft_map[ft] then
+    return M.ft_map[ft]
+  end
+end
+
+return M


### PR DESCRIPTION
## Problem

nonicons.nvim's resolution logic (ext_map, filename_map, resolve()) is
locked inside override.lua as locals. The only way to get nonicons
glyphs is through the devicons monkey-patch, so plugins that don't use
devicons can't access nonicons glyphs directly.

## Solution

Extract the resolution tables into a shared `nonicons.resolve` module
and expose `get_icon(name, ext)` and `get_icon_by_filetype(ft)` on the
public API. This lets plugins like oil.nvim consume nonicons directly
without requiring devicons.

Also fixes a case bug where `Gemfile` and `Jenkinsfile` keys in
filename_map were uppercase but `resolve()` lowercases input before
lookup, so they never matched.