### PR TITLE
ci: add vimdoc-language-server check

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -13,6 +13,7 @@ jobs:
     outputs:
       lua: ${{ steps.changes.outputs.lua }}
       markdown: ${{ steps.changes.outputs.markdown }}
+      vimdoc: ${{ steps.changes.outputs.vimdoc }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -28,6 +29,8 @@ jobs:
               - 'vim.yaml'
             markdown:
               - '*.md'
+            vimdoc:
+              - 'doc/**'
 
   lua-format:
     name: Lua Format Check
@@ -62,6 +65,18 @@ jobs:
           checklevel: Warning
           directories: lua
           configpath: .luarc.json
+
+  vimdoc-check:
+    name: Vimdoc Check
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.vimdoc == 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+      - run:
+          nix develop --command vimdoc-language-server --check doc/
+          --no-runtime-tags
 
   markdown-format:
     name: Markdown Format Check

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
       - run:
-          nix develop --command vimdoc-language-server --check doc/
+          nix develop --command vimdoc-language-server check doc/
           --no-runtime-tags
 
   markdown-format:

--- a/flake.lock
+++ b/flake.lock
@@ -115,11 +115,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1773956307,
-        "narHash": "sha256-OpE/nds7GHDBkwF94yx0m7xBqZP7aVuLgWoDxH7AskY=",
+        "lastModified": 1773957462,
+        "narHash": "sha256-mBgdC5AC4fTn7vJEMND3pH4gfL5sFKAOu9C4mK2KR6o=",
         "owner": "barrettruth",
         "repo": "vimdoc-language-server",
-        "rev": "b2d6fd1d4dc0066a57d2df62314240b603b71d83",
+        "rev": "b4c0a8cc4dbc3cc759ddc18fcec2365504b8b23e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,23 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1771177547,
@@ -16,10 +34,48 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1772624091,
+        "narHash": "sha256-QKyJ0QGWBn6r0invrMAK8dmJoBYWoOWy7lN+UHzW1jc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "80bdc1e5ce51f56b19791b52b2901187931f5353",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
-        "systems": "systems"
+        "systems": "systems",
+        "vimdoc-language-server": "vimdoc-language-server"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "vimdoc-language-server",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772852295,
+        "narHash": "sha256-3FB/WzLZSiU2Mc50C9q9VXU1LRUZbsU6UHKmZG1C+hU=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "c10801f59c68e14c308aea8fa6b0b3d81d43c61e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {
@@ -34,6 +90,41 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "vimdoc-language-server": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_2",
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1773956307,
+        "narHash": "sha256-OpE/nds7GHDBkwF94yx0m7xBqZP7aVuLgWoDxH7AskY=",
+        "owner": "barrettruth",
+        "repo": "vimdoc-language-server",
+        "rev": "b2d6fd1d4dc0066a57d2df62314240b603b71d83",
+        "type": "github"
+      },
+      "original": {
+        "owner": "barrettruth",
+        "repo": "vimdoc-language-server",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -4,12 +4,14 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     systems.url = "github:nix-systems/default";
+    vimdoc-language-server.url = "github:barrettruth/vimdoc-language-server";
   };
 
   outputs =
     {
       nixpkgs,
       systems,
+      vimdoc-language-server,
       ...
     }:
     let
@@ -26,6 +28,7 @@
             pkgs.stylua
             pkgs.selene
             pkgs.lua-language-server
+            vimdoc-language-server.packages.${pkgs.system}.default
           ];
         };
       });

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -7,3 +7,4 @@ nix develop --command prettier --check .
 nix fmt
 git diff --exit-code -- '*.nix'
 nix develop --command lua-language-server --check . --checklevel=Warning
+nix develop --command vimdoc-language-server --check doc/ --no-runtime-tags

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -7,4 +7,4 @@ nix develop --command prettier --check .
 nix fmt
 git diff --exit-code -- '*.nix'
 nix develop --command lua-language-server --check . --checklevel=Warning
-nix develop --command vimdoc-language-server --check doc/ --no-runtime-tags
+nix develop --command vimdoc-language-server check doc/ --no-runtime-tags


### PR DESCRIPTION
## Problem

No CI validation that vimdoc files under `doc/` are well-formed.

## Solution

Add `vimdoc-language-server` as a flake input, include it in the devShell, and wire a `vimdoc-check` job in `quality.yaml` gated on `doc/**` path changes. Also add the check to `scripts/ci.sh`.