### PR TITLE
build: separate ci devshell to avoid overriding system neovim

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,7 @@
           packages = [
             pkgs.prettier
             pkgs.stylua
+            pkgs.neovim
             pkgs.selene
             pkgs.lua-language-server
             vimdoc-language-server.packages.${pkgs.system}.default

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,16 @@
           packages = [
             pkgs.prettier
             pkgs.stylua
+            pkgs.selene
+            pkgs.lua-language-server
+            vimdoc-language-server.packages.${pkgs.system}.default
+          ];
+        };
+
+        ci = pkgs.mkShell {
+          packages = [
+            pkgs.prettier
+            pkgs.stylua
             pkgs.neovim
             pkgs.selene
             pkgs.lua-language-server

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 set -eu
 
-nix develop --command stylua --check .
-git ls-files '*.lua' | xargs nix develop --command selene --display-style quiet
-nix develop --command prettier --check .
+nix develop .#ci --command stylua --check .
+git ls-files '*.lua' | xargs nix develop .#ci --command selene --display-style quiet
+nix develop .#ci --command prettier --check .
 nix fmt
 git diff --exit-code -- '*.nix'
-nix develop --command lua-language-server --check . --checklevel=Warning
+nix develop .#ci --command lua-language-server --check . --checklevel=Warning


### PR DESCRIPTION
## Problem

The default devshell included `pkgs.neovim` which overrode the user's system neovim (e.g. nightly) on PATH when entering the shell interactively.

## Solution

Move `pkgs.neovim` to a dedicated `ci` devshell. The default shell no longer includes neovim. `scripts/ci.sh` uses `nix develop .#ci` for all commands.