### PR TITLE
docs: rename help file and add `*nonicons*` tag

### DIFF
--- a/doc/nonicons.txt
+++ b/doc/nonicons.txt
@@ -1,23 +1,22 @@
-*nonicons.nvim.txt*                                    Nonicons for Neovim
+*nonicons.txt*                     *nonicons* *nonicons.nvim* Nonicons for Neovim
 
-Author:  Barrett Ruth <br.barrettruth@gmail.com>
-License: MIT
+Author:  Barrett Ruth <br.barrettruth@gmail.com> License: MIT
 
 ==============================================================================
-INTRODUCTION                                                   *nonicons.nvim*
+INTRODUCTION                                           *nonicons-introduction*
 
 nonicons.nvim replaces nvim-web-devicons glyphs with icons from the nonicons
-font (https://github.com/ya2s/nonicons). It wraps devicons functions so
-that any plugin using nvim-web-devicons automatically displays nonicons glyphs.
+font (https://github.com/ya2s/nonicons). It wraps devicons functions so that
+any plugin using nvim-web-devicons automatically displays nonicons glyphs.
 
 ==============================================================================
-REQUIREMENTS                                          *nonicons-requirements*
+REQUIREMENTS                                           *nonicons-requirements*
 
 - nvim-web-devicons (https://github.com/nvim-tree/nvim-web-devicons)
 - nonicons font installed in your terminal
 
 ==============================================================================
-SETUP                                                        *nonicons-setup*
+SETUP                                                         *nonicons-setup*
 
 Load nvim-web-devicons before nonicons.nvim. For example, with lazy.nvim: >lua
     {
@@ -25,12 +24,11 @@ Load nvim-web-devicons before nonicons.nvim. For example, with lazy.nvim: >lua
       dependencies = { 'nvim-tree/nvim-web-devicons' },
       lazy = false,
     }
-<
-The plugin works automatically with no configuration required. For
+< The plugin works automatically with no configuration required. For
 customization, see |nonicons-config|.
 
 ==============================================================================
-CONFIGURATION                                               *nonicons-config*
+CONFIGURATION                                                *nonicons-config*
 
 Configure via `vim.g.nonicons` before the plugin loads: >lua
     vim.g.nonicons = {
@@ -43,9 +41,9 @@ override ~
     Whether to wrap nvim-web-devicons functions with nonicons glyphs.
 
 ==============================================================================
-API                                                            *nonicons-api*
+API                                                             *nonicons-api*
 
-                                                            *nonicons.get()*
+                                                              *nonicons.get()*
 `require('nonicons').get(name)`
     Returns the nonicons character for the given icon name, or `nil` if the
     name is not in the mapping.
@@ -56,7 +54,7 @@ API                                                            *nonicons-api*
     Returns: ~
         `string?`  The single-character nonicons glyph
 
-                                                       *nonicons.get_icon()*
+                                                         *nonicons.get_icon()*
 `require('nonicons').get_icon(name, ext)`
     Returns the nonicons character for a file, resolved by filename and/or
     extension. Returns `nil` if no match is found (caller decides fallback).
@@ -70,7 +68,7 @@ API                                                            *nonicons-api*
     Returns: ~
         `string?`  The single-character nonicons glyph
 
-                                              *nonicons.get_icon_by_filetype()*
+                                             *nonicons.get_icon_by_filetype()*
 `require('nonicons').get_icon_by_filetype(ft)`
     Returns the nonicons character for a vim filetype. Returns `nil` if no
     match is found.
@@ -83,7 +81,7 @@ API                                                            *nonicons-api*
     Returns: ~
         `string?`  The single-character nonicons glyph
 
-                                                        *nonicons.mapping*
+                                                            *nonicons.mapping*
 `require('nonicons').mapping`
     The raw `table<string, integer>` mapping icon names to Unicode codepoints.
     Useful for advanced use cases where you need the codepoint directly: >lua
@@ -92,7 +90,7 @@ API                                                            *nonicons-api*
 <
 
 ==============================================================================
-RECIPES                                                    *nonicons-recipes*
+RECIPES                                                     *nonicons-recipes*
 
 Plugins that call nvim-web-devicons functions (oil.nvim, telescope.nvim,
 fzf-lua, etc.) pick up nonicons glyphs automatically. The recipes below are
@@ -204,19 +202,17 @@ nvim-tree ~
 <
 
 ==============================================================================
-FONT SETUP                                                    *nonicons-font*
+FONT SETUP                                                     *nonicons-font*
 
 The nonicons font must be installed and configured in your terminal emulator.
 
 Download the font from: https://github.com/ya2s/nonicons/releases
 
-ghostty ~
->
+ghostty ~ >
     font_codepoint_map = "U+f101-U+f25c=nonicons"
 <
 
-kitty ~
->
+kitty ~ >
     symbol_map U+F101-U+F219 Nonicons
 <
 
@@ -233,9 +229,9 @@ iTerm2 ~
     Preferences > Profiles > Text > Non-ASCII Font > select Nonicons
 
 ==============================================================================
-COMMANDS                                                  *nonicons-commands*
+COMMANDS                                                   *nonicons-commands*
 
-                                                           *:NoniconsHiTest*
+                                                             *:NoniconsHiTest*
 `:NoniconsHiTest`
     Open a scratch buffer listing every icon in the nonicons font alongside
     its name, Unicode codepoint, and which extensions / filenames / filetypes
@@ -243,7 +239,7 @@ COMMANDS                                                  *nonicons-commands*
     that resolution tables point to the intended icons.
 
 ==============================================================================
-HEALTH CHECK                                                *nonicons-health*
+HEALTH CHECK                                                 *nonicons-health*
 
 Run `:checkhealth nonicons` to verify:
 - nvim-web-devicons is available
@@ -251,7 +247,7 @@ Run `:checkhealth nonicons` to verify:
 - The mapping table loaded successfully
 
 ==============================================================================
-ACKNOWLEDGEMENTS                                    *nonicons-acknowledgements*
+ACKNOWLEDGEMENTS                                   *nonicons-acknowledgements*
 
 - ya2s/nonicons (https://github.com/ya2s/nonicons) — icon font
 - ya2s/nvim-nonicons (https://github.com/ya2s/nvim-nonicons) — original plugin


### PR DESCRIPTION
## Problem

Help file was `nonicons.nvim.txt` with no bare `*nonicons*` tag. No built-in collision exists, so both forms should resolve.

## Solution

Rename to `nonicons.txt`, add `*nonicons*` and `*nonicons.nvim*` on the first line, deduplicate the introduction tag.