### PR TITLE
ci: make just the task source of truth

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -8,83 +8,16 @@ on:
     branches: [main]
 
 jobs:
-  changes:
+  quality:
+    name: Quality
     runs-on: ubuntu-latest
-    outputs:
-      lua: ${{ steps.changes.outputs.lua }}
-      markdown: ${{ steps.changes.outputs.markdown }}
-      vimdoc: ${{ steps.changes.outputs.vimdoc }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          filters: |
-            lua:
-              - 'lua/**'
-              - 'plugin/**'
-              - '*.lua'
-              - '.luarc.json'
-              - '*.toml'
-              - 'vim.yaml'
-            markdown:
-              - '*.md'
-            vimdoc:
-              - 'doc/**'
-
-  lua-format:
-    name: Lua Format Check
-    runs-on: ubuntu-latest
-    needs: changes
-    if: ${{ needs.changes.outputs.lua == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
-      - run: nix develop --command stylua --check .
-
-  lua-lint:
-    name: Lua Lint Check
-    runs-on: ubuntu-latest
-    needs: changes
-    if: ${{ needs.changes.outputs.lua == 'true' }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v31
-      - run: nix develop --command selene --display-style quiet .
-
-  lua-typecheck:
-    name: Lua Type Check
-    runs-on: ubuntu-latest
-    needs: changes
-    if: ${{ needs.changes.outputs.lua == 'true' }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run Lua LS Type Check
-        uses: mrcjkb/lua-typecheck-action@v0
-        with:
-          checklevel: Warning
-          directories: lua
-          configpath: .luarc.json
-
-  vimdoc-check:
-    name: Vimdoc Check
-    runs-on: ubuntu-latest
-    needs: changes
-    if: ${{ needs.changes.outputs.vimdoc == 'true' }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v31
-      - run: nix develop --command vimdoc-language-server check doc/
-
-  markdown-format:
-    name: Markdown Format Check
-    runs-on: ubuntu-latest
-    needs: changes
-    if: ${{ needs.changes.outputs.markdown == 'true' }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v31
-      - run: nix develop --command prettier --check .
+      - name: Format
+        run: nix develop .#ci --command just format
+      - name: Lint
+        run: nix develop .#ci --command just lint
 
   mapping-sync:
     name: Mapping Sync Check

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,7 @@
       devShells = forEachSystem (pkgs: {
         default = pkgs.mkShell {
           packages = [
+            pkgs.just
             pkgs.prettier
             pkgs.stylua
             pkgs.neovim
@@ -35,6 +36,7 @@
 
         ci = pkgs.mkShell {
           packages = [
+            pkgs.just
             pkgs.prettier
             pkgs.stylua
             pkgs.neovim

--- a/justfile
+++ b/justfile
@@ -1,0 +1,15 @@
+default:
+    @just --list
+
+format:
+    nix fmt -- --ci
+    stylua --check .
+    prettier --check .
+
+lint:
+    git ls-files '*.lua' | xargs selene --display-style quiet
+    lua-language-server --check . --configpath "$(pwd)/.luarc.json" --checklevel=Warning
+    vimdoc-language-server check doc/
+
+ci: format lint
+    @:

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-set -eu
-
-nix develop .#ci --command stylua --check .
-git ls-files '*.lua' | xargs nix develop .#ci --command selene --display-style quiet
-nix develop .#ci --command prettier --check .
-nix fmt
-git diff --exit-code -- '*.nix'
-nix develop .#ci --command lua-language-server --check . --checklevel=Warning


### PR DESCRIPTION
## Problem
nonicons.nvim still routed quality checks through a repo-local shell shim, so the real CI surface lived in two places and didn’t match the just-based pattern now being rolled out across the other Barrett-owned repos.

## Solution
This adds a committed repo-local justfile, exposes just in the dev and CI Nix shells, rewires the quality workflow to run the format and lint surfaces through just, preserves the repo-specific mapping-sync job, and deletes scripts/ci.sh instead of leaving a compatibility layer behind.

## Verification
I ran `nix develop .#ci --command just ci` locally in this branch, and I also reran the mapping-sync comparison against the upstream nonicons template JSON to confirm that job still passes unchanged.