### PR TITLE
chore: replace prettier with biome

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,0 @@
-node_modules/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,9 +1,0 @@
-{
-  "proseWrap": "always",
-  "printWidth": 80,
-  "tabWidth": 2,
-  "useTabs": false,
-  "trailingComma": "none",
-  "semi": false,
-  "singleQuote": true
-}

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
+  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
+  "files": { "ignoreUnknown": false },
+  "formatter": {
+    "enabled": true,
+    "formatWithErrors": false,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 80,
+    "attributePosition": "auto",
+    "bracketSameLine": false,
+    "bracketSpacing": true,
+    "expand": "auto",
+    "useEditorconfig": true,
+    "includes": ["**", "!**/node_modules/"]
+  },
+  "linter": { "enabled": true, "rules": { "recommended": true } },
+  "javascript": {
+    "formatter": {
+      "jsxQuoteStyle": "double",
+      "quoteProperties": "asNeeded",
+      "trailingCommas": "none",
+      "semicolons": "asNeeded",
+      "arrowParentheses": "always",
+      "bracketSameLine": false,
+      "quoteStyle": "single",
+      "attributePosition": "auto",
+      "bracketSpacing": true
+    }
+  },
+  "html": {
+    "formatter": {
+      "indentScriptAndStyle": false,
+      "selfCloseVoidElements": "always"
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": { "source": { "organizeImports": "on" } }
+  }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
         default = pkgs.mkShell {
           packages = [
             pkgs.just
-            pkgs.prettier
+            pkgs.biome
             pkgs.stylua
             pkgs.neovim
             pkgs.selene
@@ -35,7 +35,7 @@
         ci = pkgs.mkShell {
           packages = [
             pkgs.just
-            pkgs.prettier
+            pkgs.biome
             pkgs.stylua
             pkgs.neovim
             pkgs.selene

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ default:
 format:
     nix fmt -- --ci
     stylua --check .
-    prettier --check .
+    biome format .
 
 lint:
     git ls-files '*.lua' | xargs selene --display-style quiet

--- a/lua/nonicons/resolve.lua
+++ b/lua/nonicons/resolve.lua
@@ -322,6 +322,9 @@ M.filename_map = {
   ['eslint.config.mjs'] = 'eslint',
   ['eslint.config.ts'] = 'eslint',
 
+  ['biome.json'] = 'biome',
+  ['biome.jsonc'] = 'biome',
+
   ['.prettierrc'] = 'prettier',
   ['.prettierignore'] = 'prettier',
   ['.prettierrc.js'] = 'prettier',


### PR DESCRIPTION
This replaces Prettier with Biome in the format recipe and Nix shells, adds a migrated biome.json config, and maps biome.json and biome.jsonc to the existing Biome icon.

Verified with `nix develop .#ci --command biome format --write .`, `nix develop .#ci --command just format`, `nix develop .#ci --command just lint`, and `nix develop .#ci --command just ci`.
